### PR TITLE
Fix for Variable not declared before use

### DIFF
--- a/src/popup/sereto.js
+++ b/src/popup/sereto.js
@@ -1,6 +1,4 @@
-if (typeof browser === "undefined") {
-  var browser = chrome;
-}
+var browser = typeof globalThis.browser !== "undefined" ? globalThis.browser : chrome;
 
 function showCookiesForTab(tabs) {
   // get the first tab object in the array


### PR DESCRIPTION
Declare `browser` before any use, then perform conditional assignment.  
Best fix in this snippet: replace the top compatibility block with a declaration-first pattern:

- Declare `browser` once.
- If `browser` is unavailable globally, assign `chrome`.
- Keep behavior unchanged for environments where `browser` already exists.

In `src/popup/sereto.js`, edit lines 1–3 so the variable is declared before it is referenced.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._