### PR TITLE
Change package ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
Update the dependabot config to focus on uv lockfile